### PR TITLE
Fix crash on fetching contacts using non-property APAddressBook object

### DIFF
--- a/Classes/APAddressBook.m
+++ b/Classes/APAddressBook.m
@@ -64,7 +64,6 @@
 
 - (void)loadContacts:(void (^)(NSArray *contacts, NSError *error))callbackBlock
 {
-    __weak __typeof (self) weakSelf = self;
     APContactField fieldMask = self.fieldsMask;
     NSArray *descriptors = self.sortDescriptors;
     APContactFilterBlock filterBlock = self.filterBlock;
@@ -74,7 +73,7 @@
         NSError *error = nil;
         if (granted)
         {
-            CFArrayRef peopleArrayRef = ABAddressBookCopyArrayOfAllPeople(weakSelf.addressBook);
+            CFArrayRef peopleArrayRef = ABAddressBookCopyArrayOfAllPeople(self.addressBook);
             NSUInteger contactCount = (NSUInteger)CFArrayGetCount(peopleArrayRef);
             NSMutableArray *contacts = [[NSMutableArray alloc] init];
             for (NSUInteger i = 0; i < contactCount; i++)


### PR DESCRIPTION
Before fix demo app crashes on loadContacts block called from non-property APAddressBook object, created in some of controllers method. Like in description of usage in README file of repo. 
In "loadContacts:(void (^)(NSArray *contacts, NSError *error))callbackBlock" we don't need to worry about retain cycles. The block retains self, but self doesn't retain the block. If one or the other is released, no cycle is created and everything gets deallocated as it should.
