### PR TITLE
Added optional fetch of thumbnail photo

### DIFF
--- a/Classes/APContact.h
+++ b/Classes/APContact.h
@@ -19,6 +19,7 @@
 @property (nonatomic, readonly) NSArray *phones;
 @property (nonatomic, readonly) NSArray *emails;
 @property (nonatomic, readonly) UIImage *photo;
+@property (nonatomic, readonly) UIImage *photoThumb;
 
 - (id)initWithRecordRef:(ABRecordRef)recordRef fieldMask:(APContactField)fieldMask;
 

--- a/Classes/APContact.m
+++ b/Classes/APContact.m
@@ -43,6 +43,11 @@
             NSData *imageData = (__bridge_transfer NSData *)ABPersonCopyImageData(recordRef);
             _photo = [UIImage imageWithData:imageData scale:UIScreen.mainScreen.scale];
         }
+        if (fieldMask & APContactFieldPhotoThumb)
+        {
+            NSData *imageData = (__bridge_transfer NSData *)ABPersonCopyImageDataWithFormat(recordRef, kABPersonImageFormatThumbnail);
+            _photoThumb = [UIImage imageWithData:imageData scale:UIScreen.mainScreen.scale];
+        }
     }
     return self;
 }

--- a/Classes/APTypes.h
+++ b/Classes/APTypes.h
@@ -28,10 +28,11 @@ typedef enum
     APContactFieldPhones    = 1 << 3,
     APContactFieldEmails    = 1 << 4,
     APContactFieldPhoto     = 1 << 5,
+    APContactFieldPhotoThumb= 1 << 6,
     APContactFieldDefault   = APContactFieldFirstName | APContactFieldLastName |
                               APContactFieldPhones,
     APContactFieldAll       = APContactFieldDefault | APContactFieldCompany |
-                              APContactFieldEmails | APContactFieldPhoto
+                              APContactFieldEmails | APContactFieldPhoto | APContactFieldPhotoThumb
 } APContactField;
 
 #endif


### PR DESCRIPTION
For displaying the same cropped image the Address Book shows. It's probably also faster since the image is smaller.

Got it from here. http://stackoverflow.com/questions/8972140/getting-the-cropped-version-of-a-picture-from-the-address-book

On the demo, on `self.photoView.image = contact.photoThumb` just switch photo with photoThumb and the images on the list will change to the Address Book thumb ones.
