### PR TITLE
Added addresses and Record IDs to APContact

### DIFF
--- a/Classes/APContact.h
+++ b/Classes/APContact.h
@@ -22,6 +22,7 @@
 @property (nonatomic, readonly) NSArray *addresses;
 @property (nonatomic, readonly) UIImage *photo;
 @property (nonatomic, readonly) UIImage *thumbnail;
+@property (nonatomic, readonly) NSNumber *recordID;
 
 - (id)initWithRecordRef:(ABRecordRef)recordRef fieldMask:(APContactField)fieldMask;
 

--- a/Classes/APContact.m
+++ b/Classes/APContact.m
@@ -55,6 +55,10 @@
         {
             _addresses = [self arrayProperty:kABPersonAddressProperty fromRecord:recordRef];
         }
+        if (fieldMask & APContactFieldRecordID)
+        {
+            _recordID = [NSNumber numberWithInteger:ABRecordGetRecordID(recordRef)];
+        }
     }
     return self;
 }

--- a/Classes/APTypes.h
+++ b/Classes/APTypes.h
@@ -31,11 +31,12 @@ typedef NS_OPTIONS(NSUInteger , APContactField)
     APContactFieldThumbnail        = 1 << 6,
     APContactFieldPhonesWithLabels = 1 << 7,
     APContactFieldAddresses = 1 << 8,
+    APContactFieldRecordID = 1 << 9,
     APContactFieldDefault          = APContactFieldFirstName | APContactFieldLastName |
                                      APContactFieldPhones,
     APContactFieldAll              = APContactFieldDefault | APContactFieldCompany |
                                      APContactFieldEmails | APContactFieldPhoto |
-                                     APContactFieldThumbnail | APContactFieldPhonesWithLabels | APContactFieldAddresses
+                                     APContactFieldThumbnail | APContactFieldPhonesWithLabels | APContactFieldAddresses | APContactFieldRecordID
 };
 
 #endif


### PR DESCRIPTION
I had a need for access to contact addresses, and address book record ids (for re-accessing at a later date), so I added those properties and field mask options. So far everything seems quite sane and stable, and the changes are quite minimal, so I thought I'd push it upstream.

The only thing of note about this is that `APContact`'s addresses property is an `NSArray` of `NSDictionaries`, accessed using the `kABPersonAddress<blank>Key` constants from the `AddressBook` framework. Since that's different from the rest of `APContact`, it should probably be documented somewhere.

Thanks for the great library, it's quite useful and was _very_ easy to extend.
