### PR TITLE
Updated APAddressBookAccess declaration

### DIFF
--- a/Pod/Core/APTypes.h
+++ b/Pod/Core/APTypes.h
@@ -11,12 +11,12 @@
 
 @class APContact;
 
-typedef enum
+typedef NS_ENUM(NSUInteger, APAddressBookAccess)
 {
     APAddressBookAccessUnknown = 0,
     APAddressBookAccessGranted = 1,
     APAddressBookAccessDenied  = 2
-} APAddressBookAccess;
+};
 
 typedef BOOL(^APContactFilterBlock)(APContact *contact);
 


### PR DESCRIPTION
Changed the definition of <code>APAddressBookAccess</code> to use <code>NS_ENUM</code> so that Swift knows how to convert <code>APAddressBookAccess</code> for bridging.
