### PR TITLE
added getContactByRecordID method

### DIFF
--- a/Pod/Core/APAddressBook.h
+++ b/Pod/Core/APAddressBook.h
@@ -26,4 +26,6 @@
 - (void)startObserveChangesWithCallback:(void (^)())callback;
 - (void)stopObserveChanges;
 
+- (APContact*) getContactByRecordID:(NSNumber*)recordID;
+
 @end

--- a/Pod/Core/APAddressBook.m
+++ b/Pod/Core/APAddressBook.m
@@ -162,4 +162,15 @@ void APAddressBookExternalChangeCallback(ABAddressBookRef __unused addressBookRe
     addressBook.changeCallback ? addressBook.changeCallback() : nil;
 }
 
+#pragma mark - contact getter
+
+- (APContact*) getContactByRecordID:(NSNumber*)recordID
+{
+    // GET rule, we dont have to release `ref`
+    ABRecordRef ref = ABAddressBookGetPersonWithRecordID(self.addressBook, recordID.intValue);
+
+    return [[APContact alloc] initWithRecordRef:ref fieldMask:self.fieldsMask];
+}
+
+
 @end

--- a/Pod/Core/APAddressBook.m
+++ b/Pod/Core/APAddressBook.m
@@ -166,15 +166,19 @@ void APAddressBookExternalChangeCallback(ABAddressBookRef __unused addressBookRe
 
 - (APContact*) getContactByRecordID:(NSNumber*)recordID
 {
-    // GET rule, we dont have to release `ref`
-    ABRecordRef ref = ABAddressBookGetPersonWithRecordID(self.addressBook, recordID.intValue);
+    __block APContact * newContact = nil;
+    dispatch_sync(self.localQueue, ^
+                  {
+                      // GET rule, we dont have to release `ref`
+                      ABRecordRef ref = ABAddressBookGetPersonWithRecordID(self.addressBook, recordID.intValue);
 
-    if (ref == NULL) {
-        return nil;
-    }
+                      if (ref != NULL) {
+                          newContact =  [[APContact alloc] initWithRecordRef:ref fieldMask:self.fieldsMask];
+                      }
 
-    return [[APContact alloc] initWithRecordRef:ref fieldMask:self.fieldsMask];
-}
+                  });
+
+    return newContact;}
 
 
 @end

--- a/Pod/Core/APAddressBook.m
+++ b/Pod/Core/APAddressBook.m
@@ -169,6 +169,10 @@ void APAddressBookExternalChangeCallback(ABAddressBookRef __unused addressBookRe
     // GET rule, we dont have to release `ref`
     ABRecordRef ref = ABAddressBookGetPersonWithRecordID(self.addressBook, recordID.intValue);
 
+    if (ref == NULL) {
+        return nil;
+    }
+
     return [[APContact alloc] initWithRecordRef:ref fieldMask:self.fieldsMask];
 }
 

--- a/Pod/Core/APContact.m
+++ b/Pod/Core/APContact.m
@@ -142,8 +142,10 @@
         if (phone)
         {
             NSString *label = [self localizedLabelFromMultiValue:multiValue index:index];
+            NSString *rawLabel = [self rawLabelFromMultiValue:multiValue index:index];
             APPhoneWithLabel *phoneWithLabel = [[APPhoneWithLabel alloc] initWithPhone:phone
-                                                                                 label:label];
+                                                                                 label:label
+                                                                              rawlabel:rawLabel];
             [array addObject:phoneWithLabel];
         }
     }];
@@ -156,6 +158,16 @@
                                  kABPersonImageFormatThumbnail;
     NSData *data = (__bridge_transfer NSData *)ABPersonCopyImageDataWithFormat(recordRef, format);
     return [UIImage imageWithData:data scale:UIScreen.mainScreen.scale];
+}
+
+-(NSString*)rawLabelFromMultiValue:(ABMultiValueRef)multiValue index:(NSUInteger)index
+{
+    ABMultiValueIdentifier ident = ABMultiValueGetIdentifierAtIndex(multiValue, index);
+
+    NSString *label;
+    CFTypeRef rawLabel = ABMultiValueCopyLabelAtIndex(multiValue, index);
+    label = (__bridge_transfer NSString *)rawLabel;
+    return label;
 }
 
 - (NSString *)localizedLabelFromMultiValue:(ABMultiValueRef)multiValue index:(NSUInteger)index

--- a/Pod/Core/APPhoneWithLabel.h
+++ b/Pod/Core/APPhoneWithLabel.h
@@ -12,7 +12,8 @@
 
 @property (nonatomic, readonly) NSString *phone;
 @property (nonatomic, readonly) NSString *label;
+@property (nonatomic, readonly) NSString *rawLabel;
 
-- (id)initWithPhone:(NSString *)phone label:(NSString *)label;
+- (id)initWithPhone:(NSString *)phone label:(NSString *)label rawlabel:(NSString*)rawlabel;
 
 @end

--- a/Pod/Core/APPhoneWithLabel.m
+++ b/Pod/Core/APPhoneWithLabel.m
@@ -10,14 +10,20 @@
 
 @implementation APPhoneWithLabel
 
-- (id)initWithPhone:(NSString *)phone label:(NSString *)label {
+- (id)initWithPhone:(NSString *)phone label:(NSString *)label rawlabel:(NSString*)rawlabel {
     self = [super init];
     if(self)
     {
         _phone = phone;
         _label = label;
+        _rawLabel = rawlabel;
     }
     return self;
+}
+
+-(NSString*)description
+{
+    return [NSString stringWithFormat:@"%@ (%@) - %@", _label, _rawLabel, _phone];
 }
 
 @end


### PR DESCRIPTION
Implements #32 

Allow direct instantiation of a APContact based on the recordID 
(recordID is a fairly permanent ID to uniquely identify this contact record on the particular device).
