### PR TITLE
Adding "getContactsVcard" method to APAddressBook

### DIFF
--- a/APAddressBook.podspec
+++ b/APAddressBook.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "APAddressBook"
-  s.version      = "0.1.11"
+  s.version      = "0.1.12"
   s.summary      = "Easy access to iOS address book"
   s.homepage     = "https://github.com/Alterplay/APAddressBook"
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }

--- a/APAddressBook.podspec
+++ b/APAddressBook.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "APAddressBook"
-  s.version      = "0.1.12"
+  s.version      = "0.1.11"
   s.summary      = "Easy access to iOS address book"
   s.homepage     = "https://github.com/Alterplay/APAddressBook"
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }

--- a/Pod/Core/APAddressBook.h
+++ b/Pod/Core/APAddressBook.h
@@ -21,7 +21,7 @@
 + (void)requestAccess:(void (^)(BOOL granted, NSError * error))completionBlock;
 + (void)requestAccessOnQueue:(dispatch_queue_t)queue
                   completion:(void (^)(BOOL granted, NSError * error))completionBlock;
-+ (NSString *)getContactsVcard:(APContact *)contacts withImage:(BOOL)copyImage;
++ (NSString *)getContactsVcard:(NSArray *)contacts withImage:(BOOL)copyImage;
 
 - (void)loadContacts:(void (^)(NSArray *contacts, NSError *error))completionBlock;
 - (void)loadContactsOnQueue:(dispatch_queue_t)queue

--- a/Pod/Core/APAddressBook.h
+++ b/Pod/Core/APAddressBook.h
@@ -21,6 +21,7 @@
 + (void)requestAccess:(void (^)(BOOL granted, NSError * error))completionBlock;
 + (void)requestAccessOnQueue:(dispatch_queue_t)queue
                   completion:(void (^)(BOOL granted, NSError * error))completionBlock;
++ (NSString *)getContactsVcard:(APContact *)contacts withImage:(BOOL)copyImage;
 
 - (void)loadContacts:(void (^)(NSArray *contacts, NSError *error))completionBlock;
 - (void)loadContactsOnQueue:(dispatch_queue_t)queue

--- a/Pod/Core/APAddressBook.m
+++ b/Pod/Core/APAddressBook.m
@@ -107,7 +107,7 @@ void APAddressBookExternalChangeCallback(ABAddressBookRef addressBookRef, CFDict
         }
     }
     
-    NSArray* naitiveContacts = [contacts valueForKey: @"recordID"];
+    NSArray* naitiveContacts = [contacts valueForKey: @"originalABRecord"];
     CFDataRef vcards = (CFDataRef)ABPersonCreateVCardRepresentationWithPeople((__bridge CFArrayRef)(naitiveContacts));
     NSString *vcardString = [[NSString alloc] initWithData:(__bridge NSData *)vcards encoding:NSUTF8StringEncoding];
     

--- a/Pod/Core/APContact.h
+++ b/Pod/Core/APContact.h
@@ -32,6 +32,7 @@
 @property (nonatomic, readonly) NSArray *socialProfiles;
 @property (nonatomic, readonly) NSString *note;
 @property (nonatomic, readonly) NSArray *linkedRecordIDs;
+@property (nonatomic, readonly) ABRecordRef originalABRecord;
 
 - (id)initWithRecordRef:(ABRecordRef)recordRef fieldMask:(APContactField)fieldMask;
 

--- a/Pod/Core/APContact.m
+++ b/Pod/Core/APContact.m
@@ -20,6 +20,8 @@
     self = [super init];
     if (self)
     {
+	// Preserve original ABAddressBook record for future use (like generating vCard)
+        _originalABRecord = recordRef;
         _fieldMask = fieldMask;
         if (fieldMask & APContactFieldFirstName)
         {


### PR DESCRIPTION
I added a method that uses Apple's native method "ABPersonCreateVCardRepresentationWithPeople"

Using this method you can get the vCard string for a single or multiple contacts.

I also added an option to not get the "PHOTO" inside the vCard (this really makes the string very large and a lot of users will not want the photo in the vCard"

https://en.wikipedia.org/wiki/VCard

Let me know if you want me to add anything else before 