### PR TITLE
Add source attributes

### DIFF
--- a/Pod/Core/APContact.h
+++ b/Pod/Core/APContact.h
@@ -33,6 +33,7 @@
 @property (nonatomic, readonly) NSString *note;
 @property (nonatomic, readonly) NSArray *linkedRecordIDs;
 @property (nonatomic, readonly) NSString *sourceType;
+@property (nonatomic, readonly) NSNumber *sourceID;
 
 - (id)initWithRecordRef:(ABRecordRef)recordRef fieldMask:(APContactField)fieldMask;
 

--- a/Pod/Core/APContact.h
+++ b/Pod/Core/APContact.h
@@ -32,6 +32,7 @@
 @property (nonatomic, readonly) NSArray *socialProfiles;
 @property (nonatomic, readonly) NSString *note;
 @property (nonatomic, readonly) NSArray *linkedRecordIDs;
+@property (nonatomic, readonly) NSString *sourceType;
 
 - (id)initWithRecordRef:(ABRecordRef)recordRef fieldMask:(APContactField)fieldMask;
 

--- a/Pod/Core/APContact.m
+++ b/Pod/Core/APContact.m
@@ -126,6 +126,11 @@
             ABRecordRef source = ABPersonCopySource(recordRef);
             _sourceType = [self stringProperty:kABSourceNameProperty fromRecord:source]; ////(__bridge NSString *)((CFStringRef)ABRecordCopyValue(source, kABSourceNameProperty));
         }
+        if (fieldMask & APContactFieldSourceID)
+        {
+            ABRecordRef source = ABPersonCopySource(recordRef);
+            _recordID = @(ABRecordGetRecordID(source));
+        }
     }
     return self;
 }

--- a/Pod/Core/APContact.m
+++ b/Pod/Core/APContact.m
@@ -124,7 +124,7 @@
         if (fieldMask & APContactFieldSourceType)
         {
             ABRecordRef source = ABPersonCopySource(recordRef);
-            _sourceType = [self stringProperty:kABSourceNameProperty fromRecord:source]; ////(__bridge NSString *)((CFStringRef)ABRecordCopyValue(source, kABSourceNameProperty));
+            _sourceType = [self stringProperty:kABSourceNameProperty fromRecord:source];
         }
         if (fieldMask & APContactFieldSourceID)
         {

--- a/Pod/Core/APContact.m
+++ b/Pod/Core/APContact.m
@@ -121,6 +121,11 @@
             [linkedRecordIDs removeObject:@(ABRecordGetRecordID(recordRef))];
             _linkedRecordIDs = linkedRecordIDs.array;
         }
+        if (fieldMask & APContactFieldSourceType)
+        {
+            ABRecordRef source = ABPersonCopySource(recordRef);
+            _sourceType = [self stringProperty:kABSourceNameProperty fromRecord:source]; ////(__bridge NSString *)((CFStringRef)ABRecordCopyValue(source, kABSourceNameProperty));
+        }
     }
     return self;
 }

--- a/Pod/Core/APContact.m
+++ b/Pod/Core/APContact.m
@@ -129,7 +129,7 @@
         if (fieldMask & APContactFieldSourceID)
         {
             ABRecordRef source = ABPersonCopySource(recordRef);
-            _recordID = @(ABRecordGetRecordID(source));
+            _sourceID = @(ABRecordGetRecordID(source));
         }
     }
     return self;

--- a/Pod/Core/APTypes.h
+++ b/Pod/Core/APTypes.h
@@ -43,6 +43,7 @@ typedef NS_OPTIONS(NSUInteger , APContactField)
     APContactFieldDefault          = APContactFieldFirstName | APContactFieldLastName |
                                      APContactFieldPhones,
     APContactFieldSourceType       = 1 << 18,
+    APContactFieldSourceID         = 1 << 19,
     APContactFieldAll              = 0xFFFFFFFF
 };
 

--- a/Pod/Core/APTypes.h
+++ b/Pod/Core/APTypes.h
@@ -42,6 +42,7 @@ typedef NS_OPTIONS(NSUInteger , APContactField)
     APContactFieldJobTitle         = 1 << 17,
     APContactFieldDefault          = APContactFieldFirstName | APContactFieldLastName |
                                      APContactFieldPhones,
+    APContactFieldSourceType       = 1 << 18,
     APContactFieldAll              = 0xFFFFFFFF
 };
 

--- a/Pod/Core/APTypes.h
+++ b/Pod/Core/APTypes.h
@@ -40,10 +40,10 @@ typedef NS_OPTIONS(NSUInteger , APContactField)
     APContactFieldNote             = 1 << 15,
     APContactFieldLinkedRecordIDs  = 1 << 16,
     APContactFieldJobTitle         = 1 << 17,
-    APContactFieldDefault          = APContactFieldFirstName | APContactFieldLastName |
-                                     APContactFieldPhones,
     APContactFieldSourceType       = 1 << 18,
     APContactFieldSourceID         = 1 << 19,
+    APContactFieldDefault          = APContactFieldFirstName | APContactFieldLastName |
+                                     APContactFieldPhones,
     APContactFieldAll              = 0xFFFFFFFF
 };
 


### PR DESCRIPTION
I wanted to be able to identify the source of a contact, in order to garner more information about a pulling in contacts from multiple sources.

I added 2 properties to APContact.

sourceType: NSString - The String description of the contact's source type (https://developer.apple.com/library/ios/documentation/AddressBook/Reference/ABSourceRef_iPhoneOS/#//apple_ref/doc/constant_group/Source_Types)

sourceID: NSNumber - The id of contact's source.

