### PR TITLE
Set access even when the ABAddressBookRef isn't initialized

### DIFF
--- a/Pod/Core/Public/APAddressBook.m
+++ b/Pod/Core/Public/APAddressBook.m
@@ -36,9 +36,9 @@
     [self.thread dispatchAsync:^
     {
         APAddressBookRefWrapper *refWrapper = [[APAddressBookRefWrapper alloc] init];
+        self.access = [[APAddressBookAccessRoutine alloc] initWithAddressBookRefWrapper:refWrapper];
         if (!refWrapper.error)
         {
-            self.access = [[APAddressBookAccessRoutine alloc] initWithAddressBookRefWrapper:refWrapper];
             self.contacts = [[APAddressBookContactsRoutine alloc] initWithAddressBookRefWrapper:refWrapper];
             self.externalChange = [[APAddressBookExternalChangeRoutine alloc] initWithAddressBookRefWrapper:refWrapper];
             self.externalChange.delegate = self;


### PR DESCRIPTION
If permissions are disabled, then `refWrapper.error` will be non nil. Currently, this will prevent `self.access` from being initialized. Because of this, later in `loadContactsOnQueue:completion:`, when `[self.access requestAccessWithCompletion:]` is called it will be a no-op and thus prevent the callback from ever being called.

In other words, `-loadContacts:` will never call its completion block when permissions are disabled.

This fixes the issue by initializing `self.access` regardless of whether address book initialization errors.