### PR TITLE
Fix recently introduced social profile crash

### DIFF
--- a/Pod/Core/Private/Extractors/APContactDataExtractor.m
+++ b/Pod/Core/Private/Extractors/APContactDataExtractor.m
@@ -113,7 +113,10 @@
         NSString *socialService = dictionary[(__bridge NSString *)kABPersonSocialProfileServiceKey];
         profile.socialNetwork = [APSocialServiceHelper socialNetworkTypeWithString:socialService];
         NSString *urlString = dictionary[(__bridge NSString *)kABPersonSocialProfileURLKey];
-        profile.url = [[NSURL alloc] initWithString:urlString];
+        if (urlString)
+        {
+            profile.url = [[NSURL alloc] initWithString:urlString];
+        }
         profile.username = dictionary[(__bridge NSString *)kABPersonSocialProfileUsernameKey];
         profile.userIdentifier = dictionary[(__bridge NSString *)kABPersonSocialProfileUserIdentifierKey];
         [profiles addObject:profile];


### PR DESCRIPTION
Cause of the crash: trying to initialize `NSURL` with `nil` value. This is introduced in
e06316a9b3da2ab513ec382ea70beb450fa3467d.

This is the message after crash:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSURL
initWithString:relativeToURL:]: nil string parameter'
```